### PR TITLE
fix: meta title about us

### DIFF
--- a/app/routes/tentang-kami.tsx
+++ b/app/routes/tentang-kami.tsx
@@ -9,7 +9,7 @@ export const handle: Handle = { name: 'Tentang Kami' }
 
 export const meta: MetaFunction = () => {
   return {
-    title: `Senarai | ${handle}`,
+    title: `Senarai | ${handle.name}`,
     description: `Sekilas tentang kurator Senarai`,
   }
 }

--- a/e2e/tentang-kami.test.ts
+++ b/e2e/tentang-kami.test.ts
@@ -1,0 +1,10 @@
+import { test } from './base-test'
+
+const { expect } = test
+
+test('About us contains Tentang Kami title', async ({ page }) => {
+  await page.goto('/tentang-kami')
+
+  // Expect the title to be Tentang Kami.
+  await expect(page).toHaveTitle(/Tentang Kami/)
+})


### PR DESCRIPTION
Closes #28 

#### before 

<img width="486" alt="Screen Shot 2022-09-30 at 08 12 50" src="https://user-images.githubusercontent.com/45778229/193433707-56173dd5-c3bf-4b7d-8be1-334554d7d8c4.png">


#### after

<img width="478" alt="Screen Shot 2022-09-30 at 08 13 15" src="https://user-images.githubusercontent.com/45778229/193433708-c8018f97-ddd1-4c1d-84e3-5066d4bfb60a.png">
