### PR TITLE
docs: how to setup local dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ then automatically be deployed by Vercel, through its
 
 ## Development
 
-To run your Remix app locally, make sure your project's local dependencies are
-installed:
+To run the app locally, make sure your project's already run the setup scripts
+(this will install dependencies and setup the database):
 
 ```sh
-npm install
+npm run setup
 ```
 
 Afterwards, start the Remix development server like so:

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "fetch": "node --require esbuild-register app/scripts/fetch-db.ts",
     "format": "pkode format",
     "lint": "pkode lint",
-    "setup": "npm install && npm run fetch && npm run reset:prisma",
+    "setup": "npm install && npm run fetch && cp -r .env.example .env && npm run reset:prisma",
     "setup:e2e": "npm run fetch && cross-env DATABASE_URL=file:./test.db npm run reset:prisma && npm run build:css",
     "start:e2e": "cross-env DATABASE_URL=file:./test.db npm run dev:remix",
     "test:e2e": "playwright test",


### PR DESCRIPTION
## Description

When the first cloned the application on my local computer, I was confused about how to run the application. Apparently, there was a script for setup but it is not documented in the readme, and the script doesn't copy the `.env.example` file into `.env` file